### PR TITLE
multiple processes in the same root write indistinguishable snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Load the add-on in your application:
     var heapdump = require('heapdump');
 
 The module exports a single, no-arg function called `writeSnapshot()` that
-writes a `heapdump-xxxx.xxxx.heapsnapshot` file to the application's current
-directory.
+writes a `heapdump-<pid>.<sec>.<usec>.heapsnapshot` file to the application's current
+directory:
 
     heapdump.writeSnapshot();
 

--- a/src/heapdump.cc
+++ b/src/heapdump.cc
@@ -25,8 +25,6 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <assert.h>
-#include <sys/types.h>
-#include <unistd.h>
 
 using v8::Arguments;
 using v8::FunctionTemplate;
@@ -116,10 +114,10 @@ void WriteSnapshotHelper()
   uint64_t now = uv_hrtime();
   unsigned long sec = static_cast<unsigned long>(now / 1000000);
   unsigned long usec = static_cast<unsigned long>(now % 1000000);
-  long ppid = (long) getppid();
+  long pid = heapdump::GetPID();
 
   char filename[256];
-  snprintf(filename, sizeof(filename), "heapdump-%ld.%lu.%lu.log", ppid, sec, usec);
+  snprintf(filename, sizeof(filename), "heapdump-%ld.%lu.%lu.log", pid, sec, usec);
   FILE* fp = fopen(filename, "w");
   if (fp == NULL) return;
 
@@ -138,7 +136,7 @@ void WriteSnapshotHelper()
   snprintf(filename,
            sizeof(filename),
            "heapdump-%ld.%lu.%lu.heapsnapshot",
-           ppid, 
+           pid, 
            sec,
            usec);
   fp = fopen(filename, "w");

--- a/src/heapdump.h
+++ b/src/heapdump.h
@@ -23,6 +23,7 @@ namespace heapdump
 // Implemented in platform-posix.cc and platform-win32.cc.
 void PlatformInit();
 void WriteSnapshot();
+long GetPID();
 
 // Shared helper function, called by the platform WriteSnapshot().
 void WriteSnapshotHelper();

--- a/src/platform-posix.cc
+++ b/src/platform-posix.cc
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <signal.h>
 #include <unistd.h>
+#include <sys/types.h>
 
 namespace
 {
@@ -69,6 +70,11 @@ void WriteSnapshot()
   setsid();
   WriteSnapshotHelper();
   _exit(42);
+}
+
+long GetPID()
+{
+  return (long) getppid();
 }
 
 } // namespace heapdump

--- a/src/platform-win32.cc
+++ b/src/platform-win32.cc
@@ -15,6 +15,7 @@
  */
 
 #include "heapdump.h"
+#include <Windows.h>
 
 namespace heapdump {
 
@@ -25,6 +26,12 @@ void PlatformInit()
 void WriteSnapshot()
 {
   WriteSnapshotHelper();
+}
+
+// Win32 DWORD is unsigned; overflow will look funny
+long GetPID()
+{
+  return (long) GetCurrentProcessId();
 }
 
 } // namespace heapdump


### PR DESCRIPTION
.. I suppose another way of handling this would be to allow passing of a base filename.  In any case:

There's no easy way to distinguish snapshots from different processes started in the same hierarchy, and there's some (small) chance that they'd overwrite each other's snapshots.  I added a distinguishing PID to the filename, which uses the parent's PID on UNIX and (hopefully, I have no way to test) the process' own PID on win32.

Win32 and posix differ in PIDs -- win32 uses DWORD (unsigned long), posix PIDs are signed -- so there's some chance that win32 users would see negative PIDs after my cast to long.. fixing that generically moves logic around too much, I'm leaving that as-is.
