### PR TITLE
Fixed a memory leak in heapdump.cc on Windows & made compilation succeed with node v.0.10.24

### DIFF
--- a/src/heapdump.h
+++ b/src/heapdump.h
@@ -18,6 +18,7 @@
 #define NODE_HEAPDUMP_H_
 
 #include "v8.h"
+#include "node.h"
 
 namespace heapdump
 {

--- a/src/platform-posix.cc
+++ b/src/platform-posix.cc
@@ -30,7 +30,6 @@
 
 namespace heapdump
 {
-
 using v8::Isolate;
 
 uv_signal_t signal_handle;
@@ -92,5 +91,4 @@ void PlatformInit(Isolate* isolate)
     signal_handle.data = isolate;
   }
 }
-
 } // namespace heapdump

--- a/src/platform-win32.cc
+++ b/src/platform-win32.cc
@@ -15,6 +15,7 @@
  */
 
 #include "heapdump.h"
+
 #include "v8.h"
 
 namespace heapdump {
@@ -29,5 +30,4 @@ bool WriteSnapshot(Isolate* isolate, const char* filename)
 {
   return WriteSnapshotHelper(isolate, filename);
 }
-
 } // namespace heapdump


### PR DESCRIPTION
Heap snapshots are kept inside the win32 node process and if I take snapshots regularly the memory footprint of node grows without bounds (ironically). This patch deletes the snapshot after it is saved to disk. Apparently all the functionality of the module is retained. 
I have not tested it with latest node (v0.11) on Windows or with v0.10 on Linux but Isolate\* pointer is forwarded correctly and appears harmless (it is never used).
