### PR TITLE
g++ and make are required to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Or, if you are running node.js v0.6 or v0.8:
 ### Build
 
     node-gyp configure build
+    
+You need to have `g++` ane `make` installed to build it.
 
 ### Usage
 


### PR DESCRIPTION
I've just tried install heapdump on Ubuntu 14.04.4 LTS and it fails.

You need to install `make` and `g++` to succeed.
`apt-get install make`
`apt-get install g++`

and then:
`npm install heapdump`