### PR TITLE
add license title

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+ISC License
+
 Copyright (c) 2012, Ben Noordhuis <info@bnoordhuis.nl>
 
 Permission to use, copy, modify, and/or distribute this software for any
@@ -13,6 +15,8 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 === src/compat.h src/compat-inl.h ===
+
+ISC License
 
 Copyright (c) 2014, StrongLoop Inc.
 


### PR DESCRIPTION
It's not strictly required, but it's useful metadata, and part of the recommended license template text (see http://choosealicense.com/licenses/isc/ and https://opensource.org/licenses/isc-license)
