### PR TITLE
README: suggest verifying snapshot size as clue to truncation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ extension.
 
 On UNIX systems, the rule of thumb for creating a heap snapshot is that it
 requires memory twice the size of the heap at the time of the snapshot.
+
+Compare the size of the snapshot vs. `process.memoryUsage().heapTotal`
+at the time of the snapshot to get a hint of a truncated snapshot.
+They should be roughly the same. A slightly smaller snapshot is normal,
+but a snapshot e.g. half the size is not.
+
 If you end up with empty or truncated snapshot files, check the output of
 `dmesg`; you may have had a run-in with the system's OOM killer or a resource
 limit enforcing policy, like `ulimit -u` (max user processes) or `ulimit -v`


### PR DESCRIPTION
See https://github.com/bnoordhuis/node-heapdump/issues/54#issuecomment-514658397 :

> The last few days, I bumped half of my app servers to twice the RAM,
> leaving ample space to heapdump. On 29 runs of `writeSnapshot` when
> heap was always 1.2GB and where callback was always called with
> `err` = `null`,
> 
> - The 9 runs on machines with 8GB RAM (~5GB available at the time of
>   `writeSnapshot`) produced snapshots between 1140MB and 1333MB.
> - The 20 runs on machines with 4GB RAM (~1GB available at the time of
>   `writeSnapshot`) produced snapshots between 100MB and 225MB.
> 
> Truncation is happening, even if the callback was called with err `null`.